### PR TITLE
chore: update mediator image version in docker-compose

### DIFF
--- a/identus-docker/docker-compose.yaml
+++ b/identus-docker/docker-compose.yaml
@@ -101,7 +101,7 @@ services:
 
   identus-mediator:
     # https://hub.docker.com/repository/docker/hyperledgeridentus/identus-mediator/general
-    image: docker.io/hyperledgeridentus/identus-mediator:1.1.0
+    image: docker.io/hyperledgeridentus/identus-mediator:1.2.0
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
This PR updates the mediator image version in docker-compose.yml to a newer stable release.

No other changes have been made to the configuration.