### PR TITLE
docs: clarify did:prism compliance status

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository aggregates assets and information used across the Identus projec
 
 - **identus-docker** – Docker Compose configuration for running the Cloud Agent, Mediator and their dependencies. See [dockerize-identus.md](identus-docker/dockerize-identus.md).
 - **resources** – Logos and documents such as the Identus Technical Charter.
+- **docs** – Project-related documentation, including [`did:prism` compliance status](docs/did-prism-compliance.md).
 - **workshops** – Example applications demonstrating how to build with the Identus SDKs.
 
 Project policies are documented in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md), [`CONTRIBUTING.md`](CONTRIBUTING.md), [`DCO.md`](DCO.md) and [`SECURITY.md`](SECURITY.md).

--- a/docs/did-prism-compliance.md
+++ b/docs/did-prism-compliance.md
@@ -1,0 +1,11 @@
+# Hyperledger Identus: `did:prism` Compliance Status
+
+This document provides a high-level overview of the `did:prism` DID method support in Hyperledger Identus.
+
+## Compliance
+Support for the `did:prism` method is currently **partial**. While it adheres to the basic structure of W3C Decentralized Identifier (DID) Core v1.0, several areas are still in development for full specification alignment. Consistent DID resolution behavior across environments and alignment of lifecycle operations across SDKs are still ongoing.
+
+## Known Limitations
+* **Long-form Interoperability:** Resolver behavior for long-form DIDs may vary across different versions and environments.
+* **Feature Parity:** Support for full lifecycle operations (update, deactivate) varies across the TypeScript, Swift, and Kotlin SDKs.
+


### PR DESCRIPTION
This PR adds a short document describing the current status of did:prism support in Hyperledger Identus.

It highlights that the support is partial and outlines a few known limitations to provide better clarity for contributors and users.

This change is documentation-only and does not affect any existing functionality.