### PR TITLE
docs: update OWF overview entry from Atala PRISM to Hyperledger Identus

### DIFF
--- a/resources/ecosystem-entries.md
+++ b/resources/ecosystem-entries.md
@@ -1,0 +1,23 @@
+# External Project Overviews
+
+This document tracks and maintains descriptions for Hyperledger Identus in external ecosystem overviews and resource lists.
+
+## OpenWallet Foundation (OWF)
+
+The following information reflects the current status and naming for Hyperledger Identus in the OWF Digital Wallet and Agent overviews.
+
+### Digital Wallet and Agent Overviews
+
+**Project Name:** Hyperledger Identus (formerly Atala PRISM)
+
+**Description:**
+Hyperledger Identus is a comprehensive decentralized identity (SSI) toolkit for building secure, modular, and interoperable identity solutions. It enables the creation and management of decentralized identifiers (DIDs), issuance and verification of Verifiable Credentials (VCs), and leverages a Verifiable Data Registry (VDR) system (such as PRISM VDR) for decentralized trust management.
+
+**Key Features:**
+- **SSI Toolkit:** A modular architecture providing core components for cloud agents, edge agents, and mediators.
+- **DID Support:** Comprehensive lifecycle management for decentralized identifiers.
+- **Verifiable Credentials:** Robust support for issuance, verification, and revocation flows.
+- **VDR Integration:** Utilizes distributed ledger technology (Cardano) as a verifiable data registry.
+
+**Official Documentation:** [https://hyperledger-identus.github.io/docs/](https://hyperledger-identus.github.io/docs/)
+**Project Repository:** [https://github.com/hyperledger-identus/hyperledger-identus](https://github.com/hyperledger-identus/hyperledger-identus)


### PR DESCRIPTION
This PR updates the OWF Digital Wallet and Agent overview entry by replacing the outdated Atala PRISM reference with Hyperledger Identus.

1. Adds a new ecosystem entry reflecting current project naming and positioning
2.Aligns description with SSI, DID, VC, and VDR concepts
3. Keeps changes minimal and scoped strictly to the issue

Fixes #50