### PR TITLE
fix: resolve network_mode host and ports conflict in workshop

### DIFF
--- a/workshops/sdjwt-medical-prescription/docker-compose.yaml
+++ b/workshops/sdjwt-medical-prescription/docker-compose.yaml
@@ -33,9 +33,6 @@ services:
   cloud-agent:
     image: hyperledgeridentus/identus-cloud-agent:2.0.0
     network_mode: "host"
-    ports:
-      - "8085:8085" # API endpoint
-      - "8090:8090" # DIDComm endpoint
     environment:
       POLLUX_DB_HOST: localhost
       POLLUX_DB_PORT: 5432
@@ -66,7 +63,7 @@ services:
       prism-node:
         condition: service_started
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://cloud-agent:8085/_system/health" ]
+      test: [ "CMD", "curl", "-f", "http://localhost:8085/_system/health" ]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -78,8 +75,6 @@ services:
   mongo:
     image: mongo:6.0
     network_mode: "host"
-    ports:
-      - "27017:27017"
     command: [ "--auth" ]
     environment:
       - MONGO_INITDB_ROOT_USERNAME=admin
@@ -91,8 +86,6 @@ services:
   identus-mediator:
     image: identus/identus-mediator:1.0.0
     network_mode: "host"
-    ports:
-      - "8080:8080"
     environment:
       # Creates the identity:
       # These keys are for demo purpose only for production deployments generate keys


### PR DESCRIPTION
## Summary

The `docker-compose.yaml` in the SD-JWT Medical Prescription workshop has two configuration issues that prevent the stack from starting correctly:

### Bug 1: Healthcheck uses unresolvable container hostname
The `cloud-agent` service healthcheck uses `http://cloud-agent:8085/_system/health`, but since the service is configured with `network_mode: "host"`, Docker's internal DNS is bypassed and container names **cannot** be resolved. This causes the healthcheck to fail indefinitely, blocking any dependent services.

**Fix:** Changed the healthcheck URL to `http://localhost:8085/_system/health`, which is the correct address under host networking.

### Bug 2: Redundant `ports:` directives with `network_mode: host`
The `cloud-agent`, `mongo`, and `identus-mediator` services all declare `ports:` mappings while also using `network_mode: "host"`. Docker [ignores `ports:` entirely](https://docs.docker.com/reference/compose-file/services/#network_mode) when host networking is used, making these directives misleading dead config. Docker also emits a warning:
> Published ports are discarded when using host network mode

**Fix:** Removed the `ports:` blocks from all three affected services.

## Changes
- `workshops/sdjwt-medical-prescription/docker-compose.yaml`
  - Removed `ports:` from `cloud-agent` (8085, 8090)
  - Removed `ports:` from `mongo` (27017)
  - Removed `ports:` from `identus-mediator` (8080)
  - Fixed healthcheck URL: `cloud-agent` → `localhost`

## Testing
- ✅ `yamllint` passes with project `.yamllint.yml` config
- ✅ YAML structure validated (proper indentation, no syntax errors)
- ✅ No unrelated changes

Signed-off-by: HarshitPal25 <harshit13082006@gmail.com>
