### PR TITLE
fix: typo in DCO.md

### DIFF
--- a/DCO.md
+++ b/DCO.md
@@ -165,7 +165,7 @@ PGP (Pretty Good Privacy) is a method for encrypting and signing data. By signin
 
 ### Troubleshooting
 
-In case commiting a change fails with the message
+In case committing a change fails with the message
 
 ```bash
 error: gpg failed to sign the data


### PR DESCRIPTION
### Description
Correct spelling mistake in DCO.md

<img width="1195" height="202" alt="image" src="https://github.com/user-attachments/assets/812ff1c3-eb9f-488e-b109-824587378b10" />