### PR TITLE
chore: bump Identus Docker image versions

### DIFF
--- a/identus-docker/cloud-agent-M4-workaround/Dockerfile
+++ b/identus-docker/cloud-agent-M4-workaround/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/hyperledgeridentus/identus-cloud-agent:2.0.0
+FROM docker.io/hyperledgeridentus/identus-cloud-agent:2.2.0
 
 USER root
 RUN sed -i -e 's/"\$java_cmd"/"\$java_cmd" -XX:UseSVE=0/g' ./bin/identus-cloud-agent

--- a/identus-docker/docker-compose.yaml
+++ b/identus-docker/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
 
   cloud-agent:
     # https://hub.docker.com/repository/docker/hyperledgeridentus/identus-cloud-agent/general
-    image: docker.io/hyperledgeridentus/identus-cloud-agent:2.0.0
+    image: docker.io/hyperledgeridentus/identus-cloud-agent:2.2.0
     # build: ./cloud-agent-M4-workaround # Workaround for the M4 see https://github.com/hyperledger/identus-cloud-agent/issues/1482
     ports:
       - "8085:8085" # API endpoint
@@ -101,7 +101,7 @@ services:
 
   identus-mediator:
     # https://hub.docker.com/repository/docker/hyperledgeridentus/identus-mediator/general
-    image: docker.io/hyperledgeridentus/identus-mediator:1.2.0
+    image: docker.io/hyperledgeridentus/identus-mediator:1.2.1
     ports:
       - "8080:8080"
     environment:

--- a/identus-docker/dockerize-identus.md
+++ b/identus-docker/dockerize-identus.md
@@ -82,7 +82,7 @@ If you see the following message `No java installations was detected.` when star
 For more information check the [issues](https://github.com/hyperledger/identus-cloud-agent/issues/1482)
 
 The workaround is to disable CPU's vector extensions. So we need to create a new docker image based on the previous one.
-We do that on the [Dockerfile](./identus-docker/cloud-agent-M4-workaround/Dockerfile) (for version 2.0.0) where we hard-code the workaround.
+We do that on the [Dockerfile](./identus-docker/cloud-agent-M4-workaround/Dockerfile) (for version 2.2.0) where we hard-code the workaround.
 
 So on your docker compose file [docker-compose.yaml](identus-docker/docker-compose.yaml) you need to use the new image we just created.
 By changing the following:
@@ -90,14 +90,14 @@ By changing the following:
 - From
 
   ```yaml
-    image: docker.io/hyperledgeridentus/identus-cloud-agent:2.0.0
+    image: docker.io/hyperledgeridentus/identus-cloud-agent:2.2.0
     # build: ./cloud-agent-M4-workaround
   ```
 
 - To
 
   ```yaml
-    # image: docker.io/hyperledgeridentus/identus-cloud-agent:2.0.0
+    # image: docker.io/hyperledgeridentus/identus-cloud-agent:2.2.0
     build: ./cloud-agent-M4-workaround
   ```
 

--- a/workshops/sdjwt-medical-prescription/docker-compose.yaml
+++ b/workshops/sdjwt-medical-prescription/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
       retries: 5
 
   prism-node:
-    image: identus/prism-node:2.4.1
+    image: docker.io/inputoutput/prism-node:2.6.0
     network_mode: "host"
     environment:
       NODE_PSQL_HOST: localhost:5432
@@ -31,7 +31,7 @@ services:
         condition: service_healthy
 
   cloud-agent:
-    image: hyperledgeridentus/identus-cloud-agent:2.0.0
+    image: docker.io/hyperledgeridentus/identus-cloud-agent:2.2.0
     network_mode: "host"
     environment:
       POLLUX_DB_HOST: localhost
@@ -84,7 +84,7 @@ services:
       - ./dbs/mongo-initdb.js:/docker-entrypoint-initdb.d/initdb.js
 
   identus-mediator:
-    image: docker.io/hyperledgeridentus/identus-mediator:1.2.0
+    image: docker.io/hyperledgeridentus/identus-mediator:1.2.1
     network_mode: "host"
     environment:
       # Creates the identity:


### PR DESCRIPTION
## Summary

Bumps Identus Docker image versions to their latest releases:

- **Cloud Agent**: `2.0.0` → `2.2.0`
- **Mediator**: `1.2.0` → `1.2.1`
- **PRISM Node** (workshop): `identus/prism-node:2.4.1` → `docker.io/inputoutput/prism-node:2.6.0`

### Files changed

| File | Change |
|------|--------|
| `identus-docker/cloud-agent-M4-workaround/Dockerfile` | Cloud Agent base image 2.0.0 → 2.2.0 |
| `identus-docker/docker-compose.yaml` | Cloud Agent 2.0.0 → 2.2.0, Mediator 1.2.0 → 1.2.1 |
| `identus-docker/dockerize-identus.md` | Documentation updated to reflect new image versions |
| `workshops/sdjwt-medical-prescription/docker-compose.yaml` | PRISM Node image updated, Cloud Agent 2.0.0 → 2.2.0, Mediator 1.2.0 → 1.2.1 |

### Testing

- [ ] Verify Docker Compose pulls the new images successfully
- [ ] Confirm Cloud Agent 2.2.0 starts without regressions
- [ ] Confirm Mediator 1.2.1 starts without regressions
- [ ] Confirm workshop docker-compose works end-to-end